### PR TITLE
Add OAuth flow using Streamlit secrets

### DIFF
--- a/.streamlit/secrets.toml
+++ b/.streamlit/secrets.toml
@@ -1,0 +1,4 @@
+[google]
+client_id = "YOUR_CLIENT_ID"
+client_secret = "YOUR_CLIENT_SECRET"
+redirect_uri = "https://your-app-name.streamlit.app"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
-
 # YT Insights App
 
-This Streamlit app allows users to analyze YouTube videos using YouTube Data and Analytics APIs.
+This Streamlit app allows users to analyse YouTube videos using YouTube Data and Analytics APIs.
 
 ## Features
 
@@ -14,9 +13,16 @@ This Streamlit app allows users to analyze YouTube videos using YouTube Data and
 1. Upload this repo to GitHub
 2. Go to https://streamlit.io/cloud
 3. Connect GitHub and deploy `streamlit_app.py`
-4. Upload `client_secret.json` inside the app when prompted
+4. Set the following fields in `.streamlit/secrets.toml`:
+
+```toml
+[google]
+client_id = "YOUR_CLIENT_ID"
+client_secret = "YOUR_CLIENT_SECRET"
+redirect_uri = "https://your-app-name.streamlit.app"
+```
 
 ## Notes
 
-- Do **not** upload `client_secret.json` to GitHub.
-- You can upload it inside the app at runtime via the file uploader.
+- The OAuth client ID and secret are kept private in `.streamlit/secrets.toml`.
+- Users authenticate with their own Google accounts during runtime.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,9 @@ client_secret = "YOUR_CLIENT_SECRET"
 redirect_uri = "https://your-app-name.streamlit.app"
 ```
 
+5. Install dependencies locally with `pip install -r requirements.txt` if you
+   run the app outside Streamlit Cloud.
+
 ## Notes
 
 - The OAuth client ID and secret are kept private in `.streamlit/secrets.toml`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # YT Insights App
 
-This Streamlit app allows users to analyse YouTube videos using YouTube Data and Analytics APIs.
+This Streamlit app allows users to analyze YouTube videos using YouTube Data and Analytics APIs.
 
 ## Features
 
@@ -26,3 +26,4 @@ redirect_uri = "https://your-app-name.streamlit.app"
 
 - The OAuth client ID and secret are kept private in `.streamlit/secrets.toml`.
 - Users authenticate with their own Google accounts during runtime.
+- Login credentials are stored in `st.session_state` and can be cleared with the **Logout** button.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+google-auth-oauthlib
+google-api-python-client

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -10,7 +10,7 @@ SCOPES = [
 ]
 
 
-def get_flow():
+def get_flow() -> Flow:
     return Flow.from_client_config(
         {
             "web": {
@@ -57,6 +57,11 @@ st.set_page_config(page_title="YouTube Insights Tool")
 
 st.title("YouTube Insights Tool")
 
+# Ensure OAuth credentials are available
+if "google" not in st.secrets:
+    st.error("Google OAuth credentials missing in `secrets.toml`.")
+    st.stop()
+
 # Process OAuth2 redirect
 query_params = st.experimental_get_query_params()
 if "code" in query_params and "state" in query_params:
@@ -96,3 +101,4 @@ else:
         )
         st.session_state["state"] = state
         st.markdown(f"[Continue here]({auth_url})")
+        st.stop()

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,7 +1,78 @@
-
 import streamlit as st
+from google_auth_oauthlib.flow import Flow
+from googleapiclient.discovery import build
+from google.oauth2.credentials import Credentials
+
+SCOPES = [
+    "https://www.googleapis.com/auth/youtube.readonly",
+    "https://www.googleapis.com/auth/yt-analytics.readonly",
+]
+
+
+def get_flow():
+    return Flow.from_client_config(
+        {
+            "web": {
+                "client_id": st.secrets["google"]["client_id"],
+                "client_secret": st.secrets["google"]["client_secret"],
+                "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+                "token_uri": "https://oauth2.googleapis.com/token",
+            }
+        },
+        scopes=SCOPES,
+        redirect_uri=st.secrets["google"]["redirect_uri"],
+    )
+
+
+def creds_to_dict(creds: Credentials):
+    return {
+        "token": creds.token,
+        "refresh_token": creds.refresh_token,
+        "token_uri": creds.token_uri,
+        "client_id": creds.client_id,
+        "client_secret": creds.client_secret,
+        "scopes": creds.scopes,
+    }
+
 
 st.set_page_config(page_title="YouTube Insights Tool")
 
 st.title("YouTube Insights Tool")
-st.write("Upload your `client_secret.json` and enter a YouTube video URL to begin analysis.")
+
+# Handle OAuth2 redirect
+query_params = st.experimental_get_query_params()
+
+if "credentials" not in st.session_state:
+    if "code" in query_params and "state" in query_params:
+        if (
+            "state" in st.session_state
+            and st.session_state["state"] == query_params["state"][0]
+        ):
+            flow = get_flow()
+            flow.fetch_token(code=query_params["code"][0])
+            st.session_state.credentials = creds_to_dict(flow.credentials)
+            st.experimental_set_query_params()  # clear params
+            st.success("Successfully authenticated!")
+            st.experimental_rerun()
+    else:
+        if st.button("Login with Google"):
+            flow = get_flow()
+            auth_url, state = flow.authorization_url(
+                access_type="offline",
+                include_granted_scopes="true",
+                prompt="consent",
+            )
+            st.session_state["state"] = state
+            st.write("Please continue the login in a new tab:")
+            st.markdown(f"[Authorize]({auth_url})")
+else:
+    creds = Credentials(**st.session_state.credentials)
+    youtube = build("youtube", "v3", credentials=creds)
+    st.write("Authenticated! You can now access the API.")
+    # Example: list the user's channels
+    channels = (
+        youtube.channels()
+        .list(part="snippet,statistics", mine=True)
+        .execute()
+    )
+    st.json(channels)


### PR DESCRIPTION
## Summary
- refactor app to use a Google OAuth public flow
- document new secret-based config

## Testing
- `python -m py_compile streamlit_app.py`
- `streamlit run streamlit_app.py --server.headless true` (terminated after launch)


------
https://chatgpt.com/codex/tasks/task_e_688c20343e24832993150fb952bfc49f